### PR TITLE
Update computing covariance, thus removing the unnecessary memory allocation memory and loop

### DIFF
--- a/cpp/genz_icp/core/VoxelHashMap.hpp
+++ b/cpp/genz_icp/core/VoxelHashMap.hpp
@@ -70,6 +70,9 @@ struct VoxelHashMap {
     void AddPoints(const std::vector<Eigen::Vector3d> &points);
     void RemovePointsFarFromLocation(const Eigen::Vector3d &origin);
     std::vector<Eigen::Vector3d> Pointcloud() const;
+    std::tuple<Eigen::Vector3d, size_t, Eigen::Matrix3d, double> GetClosestNeighbor(const Eigen::Vector3d &query) const;
+    std::pair<bool, Eigen::Vector3d> DeterminePlanarity(const Eigen::Matrix3d &covariance) const;
+
 
     double voxel_size_;
     double max_distance_;


### PR DESCRIPTION
### Summary

The Genz-ICP computed the covariances of each points for determining planarity.

In the original code, the `neighbors` vector is stored within searching a closest neighbor, and the covariance is computed within another loop.

However, this is un-*efficient* in computation and memory, since the covariance can be computed when searching a closest neighbor.

(Moreover, the processes of determining planarity and searching a closest neighrbor are functionized for readability.)

### Changes

1. **Optimization of Covariance Calculation**:
    - Original Code:
        
        In the original code, the planarity was determined by storing neighbors in a vector within `GetClosestNeighbor` and calculating covariance through another loop.
        
    - Modified Code:
        
        I refactored this by applying the formula $\text{Cov}(X) = E(XX^T)-E(X)E(X)^T$ to covariance directly inside the `GetClosestNeighbor` function.
        
        In this way, the allocation memory for `neighbors` vector and the another loop for computing covariance are removed.
        
2. **Modularization of Planarity Calculation**:
    
    Some codes, originally done in a procedural way, are extracted into a separate function for readability.
    
    - Functions
        - `GetClosestNeighbor`
        - `DeterminePlanarity`