### PR TITLE
Some optimization suggestions for reducing CPU usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,7 +86,7 @@ roslaunch genz_icp odometry.launch topic:=<topic_name>
 ```sh
 rosbag play <rosbag_file_name>.bag
 ```
-
+ 
 Check out the tuning guide for the parameters of GenZ-ICP at this [link][tuning_guide_link]
 
 [tuning_guide_link]: https://github.com/cocel-postech/genz-icp/blob/master/ros/config/parameter_tuning_guide.md

--- a/README.md
+++ b/README.md
@@ -165,3 +165,4 @@ If you have any questions, please do not hesitate to contact us
 
 [dhlink]: https://github.com/Daehan2Lee
 [htlink]: https://github.com/LimHyungTae
+ 

--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@
 | *VoxelHashMap.cpp* | Precomputed Statistics in `GetClosestNeighbor`| Use `sum_points` and `sum_outer` for O(27) computation vs. O(27 * P) per query                            | 15–25% of total runtime                  |
 | *VoxelHashMap.cpp* | Efficient `AddPoints`                         | Simplify with `for` loop and `map_.at()`, maintaining precomputed stats                                  | 1–3% of total runtime                    |
 | *VoxelHashMap.cpp* | Optimized `RemovePointsFarFromLocation`       | Use iterator-based `erase` for safe and efficient removal                                                 | 1–2% of total runtime                    |
-| *Overall*          | Combined Effect                               | Cumulative impact across all optimizations, varying with point cloud size and voxel density               | **30–70% of total runtime**              |
+| *Overall*          | Combined Effect                               | Cumulative impact across all optimizations, varying with point cloud size and voxel density               | **20–50% of total runtime**              |
 ---
 
 ## :gear: How to build & run

--- a/README.md
+++ b/README.md
@@ -166,5 +166,5 @@ If you have any questions, please do not hesitate to contact us
 
 [dhlink]: https://github.com/Daehan2Lee
 [htlink]: https://github.com/LimHyungTae
-[aplink]: https://github.com/ali-pahlevani
+[aplink]: https://github.com/ali-pahlevani (Not a main author - Contributor)
  

--- a/README.md
+++ b/README.md
@@ -32,13 +32,13 @@
 ## :anger: Optimizations:
 | **File**             | **Optimization**                              | **Description**                                                                                              | **Estimated CPU Usage Reduction**         |
 |----------------------|-----------------------------------------------|--------------------------------------------------------------------------------------------------------------|-------------------------------------------|
-| *Registration.cpp* | Vectorized `TransformPoints`                  | Uses Eigen matrix operations instead of per-point `std::transform`.                                         | 5–15% of total runtime                   |
-| *Registration.cpp* | Precomputed `kernel_squared`                  | Computes `kernel * kernel` once instead of repeatedly in `Weight`.                                           | 0.5–1% of total runtime                  |
-| *Registration.cpp* | Improved Weight Function                      | Reduces operations in weight computation from 4 to 2 multiplications + 1 addition.                          | 2–5% of total runtime                    |
-| *VoxelHashMap.cpp* | Squared Distance in `GetClosestNeighbor`      | Uses `.squaredNorm()` for comparisons, with one `sqrt` at the end.                                           | 10–20% of total runtime                  |
-| *VoxelHashMap.cpp* | Precomputed Statistics in `GetClosestNeighbor`| Uses `sum_points` and `sum_outer` for O(27) computation vs. O(27 * P) per query.                            | 15–25% of total runtime                  |
-| *VoxelHashMap.cpp* | Efficient `AddPoints`                         | Simplifies with `for` loop and `map_.at()`, maintaining precomputed stats.                                  | 1–3% of total runtime                    |
-| *VoxelHashMap.cpp* | Optimized `RemovePointsFarFromLocation`       | Uses iterator-based `erase` for safe and efficient removal.                                                 | 1–2% of total runtime                    |
+| *Registration.cpp* | Vectorized `TransformPoints`                  | Use Eigen matrix operations instead of per-point `std::transform`.                                         | 5–15% of total runtime                   |
+| *Registration.cpp* | Precomputed `kernel_squared`                  | Compute `kernel * kernel` once instead of repeatedly in `Weight`.                                           | 0.5–1% of total runtime                  |
+| *Registration.cpp* | Improved Weight Function                      | Reduce operations in weight computation from 4 to 2 multiplications + 1 addition.                          | 2–5% of total runtime                    |
+| *VoxelHashMap.cpp* | Squared Distance in `GetClosestNeighbor`      | Use `.squaredNorm()` for comparisons, with one `sqrt` at the end.                                           | 10–20% of total runtime                  |
+| *VoxelHashMap.cpp* | Precomputed Statistics in `GetClosestNeighbor`| Use `sum_points` and `sum_outer` for O(27) computation vs. O(27 * P) per query.                            | 15–25% of total runtime                  |
+| *VoxelHashMap.cpp* | Efficient `AddPoints`                         | Simplify with `for` loop and `map_.at()`, maintaining precomputed stats.                                  | 1–3% of total runtime                    |
+| *VoxelHashMap.cpp* | Optimized `RemovePointsFarFromLocation`       | Use iterator-based `erase` for safe and efficient removal.                                                 | 1–2% of total runtime                    |
 | *Overall*          | Combined Effect                               | Cumulative impact across all optimizations, varying with point cloud size and voxel density.               | **30–70% of total runtime**              |
 ---
 

--- a/README.md
+++ b/README.md
@@ -123,7 +123,7 @@ ros2 bag play <rosbag_file_name>.mcap
 Check out the tuning guide for the parameters of GenZ-ICP at this [link][tuning_guide_link]
 
 ## :pushpin: Todo list
-- ✔️ Code optimization to reduce CPU load
+✔️ Code optimization to reduce CPU load
 - [ ] Python support for GenZ-ICP
 
 

--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@
 [arXivlink]: https://arxiv.org/abs/2411.06766
 
 ---
+## :anger: Optimizations:
 | **File**             | **Optimization**                              | **Description**                                                                                              | **Estimated CPU Usage Reduction**         |
 |----------------------|-----------------------------------------------|--------------------------------------------------------------------------------------------------------------|-------------------------------------------|
 | *Registration.cpp* | Vectorized `TransformPoints`                  | Uses Eigen matrix operations instead of per-point `std::transform`.                                         | 5–15% of total runtime                   |

--- a/README.md
+++ b/README.md
@@ -166,5 +166,6 @@ If you have any questions, please do not hesitate to contact us
 
 [dhlink]: https://github.com/Daehan2Lee
 [htlink]: https://github.com/LimHyungTae
-[aplink]: https://github.com/ali-pahlevani (Not a main author - Contributor)
+[aplink]: https://github.com/ali-pahlevani
+(Not a main author - Contributor)
  

--- a/README.md
+++ b/README.md
@@ -28,7 +28,8 @@
 
 [arXivlink]: https://arxiv.org/abs/2411.06766
 
-### Optimizations:
+---
+### :anger: Optimizations:
 - sdfdsf
 - fdsfds
 - fsdfd

--- a/README.md
+++ b/README.md
@@ -31,9 +31,9 @@
 ---
 | **File**             | **Optimization**                              | **Description**                                                                                              | **Estimated CPU Usage Reduction**         |
 |----------------------|-----------------------------------------------|--------------------------------------------------------------------------------------------------------------|-------------------------------------------|
-| *Registration.cpp* | Vectorized `TransformPoints`                  | Uses Eigen matrix operations instead of per-point `std::transform`.                                         | 5–15% of total runtime                   |
-| *Registration.cpp* | Precomputed `kernel_squared`                  | Computes `kernel * kernel` once instead of repeatedly in `Weight`.                                           | 0.5–1% of total runtime                  |
-| *Registration.cpp* | Improved Weight Function                      | Reduces operations in weight computation from 4 to 2 multiplications + 1 addition.                          | 2–5% of total runtime                    |
+| *Registration.cpp* | Vectorized `TransformPoints` | Uses Eigen matrix operations instead of per-point `std::transform`.                                         | 5–15% of total runtime                   |
+| *Registration.cpp* | Precomputed `kernel_squared` | Computes `kernel * kernel` once instead of repeatedly in `Weight`.                                           | 0.5–1% of total runtime                  |
+| *Registration.cpp* | Improved Weight Function | Reduces operations in weight computation from 4 to 2 multiplications + 1 addition.                          | 2–5% of total runtime                    |
 | *VoxelHashMap.cpp* | Squared Distance in `GetClosestNeighbor`      | Uses `.squaredNorm()` for comparisons, with one `sqrt` at the end.                                           | 10–20% of total runtime                  |
 | *VoxelHashMap.cpp* | Precomputed Statistics in `GetClosestNeighbor`| Uses `sum_points` and `sum_outer` for O(27) computation vs. O(27 * P) per query.                            | 15–25% of total runtime                  |
 | *VoxelHashMap.cpp* | Efficient `AddPoints`                         | Simplifies with `for` loop and `map_.at()`, maintaining precomputed stats.                                  | 1–3% of total runtime                    |

--- a/README.md
+++ b/README.md
@@ -124,7 +124,7 @@ Check out the tuning guide for the parameters of GenZ-ICP at this [link][tuning_
 
 ## :pushpin: Todo list
 ✔️ Code optimization to reduce CPU load
-- [ ] Python support for GenZ-ICP
+[ ] Python support for GenZ-ICP
 
 
 ## :pencil: Citation

--- a/README.md
+++ b/README.md
@@ -29,16 +29,16 @@
 [arXivlink]: https://arxiv.org/abs/2411.06766
 
 ---
-### | **File**             | **Optimization**                              | **Description**                                                                                              | **Estimated CPU Usage Reduction**         |
-|:---------------------:|:---------------------------------------------:|:------------------------------------------------------------------------------------------------------------:|:------------------------------------------:|
-| **Registration.cpp**  | Vectorized `TransformPoints`                  | Uses Eigen matrix operations instead of per-point `std::transform`.                                         | 5–15% of total runtime                   |
-| **Registration.cpp**  | Precomputed `kernel_squared`                  | Computes `kernel * kernel` once instead of repeatedly in `Weight`.                                           | 0.5–1% of total runtime                  |
-| **Registration.cpp**  | Improved Weight Function                      | Reduces operations in weight computation from 4 to 2 multiplications + 1 addition.                          | 2–5% of total runtime                    |
-| **VoxelHashMap.cpp**  | Squared Distance in `GetClosestNeighbor`      | Uses `.squaredNorm()` for comparisons, with one `sqrt` at the end.                                           | 10–20% of total runtime                  |
-| **VoxelHashMap.cpp**  | Precomputed Statistics in `GetClosestNeighbor`| Uses `sum_points` and `sum_outer` for O(27) computation vs. O(27 * P) per query.                            | 15–25% of total runtime                  |
-| **VoxelHashMap.cpp**  | Efficient `AddPoints`                         | Simplifies with `for` loop and `map_.at()`, maintaining precomputed stats.                                  | 1–3% of total runtime                    |
-| **VoxelHashMap.cpp**  | Optimized `RemovePointsFarFromLocation`       | Uses iterator-based `erase` for safe and efficient removal.                                                 | 1–2% of total runtime                    |
-| **Overall**           | Combined Effect                               | Cumulative impact across all optimizations, varying with point cloud size and voxel density.               | **30–70% of total runtime**              |
+| **File**             | **Optimization**                              | **Description**                                                                                              | **Estimated CPU Usage Reduction**         |
+|----------------------|-----------------------------------------------|--------------------------------------------------------------------------------------------------------------|-------------------------------------------|
+| **Registration.cpp** | Vectorized `TransformPoints`                  | Uses Eigen matrix operations instead of per-point `std::transform`.                                         | 5–15% of total runtime                   |
+| **Registration.cpp** | Precomputed `kernel_squared`                  | Computes `kernel * kernel` once instead of repeatedly in `Weight`.                                           | 0.5–1% of total runtime                  |
+| **Registration.cpp** | Improved Weight Function                      | Reduces operations in weight computation from 4 to 2 multiplications + 1 addition.                          | 2–5% of total runtime                    |
+| **VoxelHashMap.cpp** | Squared Distance in `GetClosestNeighbor`      | Uses `.squaredNorm()` for comparisons, with one `sqrt` at the end.                                           | 10–20% of total runtime                  |
+| **VoxelHashMap.cpp** | Precomputed Statistics in `GetClosestNeighbor`| Uses `sum_points` and `sum_outer` for O(27) computation vs. O(27 * P) per query.                            | 15–25% of total runtime                  |
+| **VoxelHashMap.cpp** | Efficient `AddPoints`                         | Simplifies with `for` loop and `map_.at()`, maintaining precomputed stats.                                  | 1–3% of total runtime                    |
+| **VoxelHashMap.cpp** | Optimized `RemovePointsFarFromLocation`       | Uses iterator-based `erase` for safe and efficient removal.                                                 | 1–2% of total runtime                    |
+| **Overall**          | Combined Effect                               | Cumulative impact across all optimizations, varying with point cloud size and voxel density.               | **30–70% of total runtime**              |
 ---
 
 ## :gear: How to build & run

--- a/README.md
+++ b/README.md
@@ -32,14 +32,14 @@
 ## :anger: Optimizations:
 | **File**             | **Optimization**                              | **Description**                                                                                              | **Estimated CPU Usage Reduction**         |
 |----------------------|-----------------------------------------------|--------------------------------------------------------------------------------------------------------------|-------------------------------------------|
-| *Registration.cpp* | Vectorized `TransformPoints`                  | Use Eigen matrix operations instead of per-point `std::transform`.                                         | 5–15% of total runtime                   |
-| *Registration.cpp* | Precomputed `kernel_squared`                  | Compute `kernel * kernel` once instead of repeatedly in `Weight`.                                           | 0.5–1% of total runtime                  |
-| *Registration.cpp* | Improved Weight Function                      | Reduce operations in weight computation from 4 to 2 multiplications + 1 addition.                          | 2–5% of total runtime                    |
-| *VoxelHashMap.cpp* | Squared Distance in `GetClosestNeighbor`      | Use `.squaredNorm()` for comparisons, with one `sqrt` at the end.                                           | 10–20% of total runtime                  |
-| *VoxelHashMap.cpp* | Precomputed Statistics in `GetClosestNeighbor`| Use `sum_points` and `sum_outer` for O(27) computation vs. O(27 * P) per query.                            | 15–25% of total runtime                  |
-| *VoxelHashMap.cpp* | Efficient `AddPoints`                         | Simplify with `for` loop and `map_.at()`, maintaining precomputed stats.                                  | 1–3% of total runtime                    |
-| *VoxelHashMap.cpp* | Optimized `RemovePointsFarFromLocation`       | Use iterator-based `erase` for safe and efficient removal.                                                 | 1–2% of total runtime                    |
-| *Overall*          | Combined Effect                               | Cumulative impact across all optimizations, varying with point cloud size and voxel density.               | **30–70% of total runtime**              |
+| *Registration.cpp* | Vectorized `TransformPoints`                  | Use Eigen matrix operations instead of per-point `std::transform`                                         | 5–15% of total runtime                   |
+| *Registration.cpp* | Precomputed `kernel_squared`                  | Compute `kernel * kernel` once instead of repeatedly in `Weight`                                           | 0.5–1% of total runtime                  |
+| *Registration.cpp* | Improved Weight Function                      | Reduce operations in weight computation from 4 to 2 multiplications + 1 addition                          | 2–5% of total runtime                    |
+| *VoxelHashMap.cpp* | Squared Distance in `GetClosestNeighbor`      | Use `.squaredNorm()` for comparisons, with one `sqrt` at the end                                           | 10–20% of total runtime                  |
+| *VoxelHashMap.cpp* | Precomputed Statistics in `GetClosestNeighbor`| Use `sum_points` and `sum_outer` for O(27) computation vs. O(27 * P) per query                            | 15–25% of total runtime                  |
+| *VoxelHashMap.cpp* | Efficient `AddPoints`                         | Simplify with `for` loop and `map_.at()`, maintaining precomputed stats                                  | 1–3% of total runtime                    |
+| *VoxelHashMap.cpp* | Optimized `RemovePointsFarFromLocation`       | Use iterator-based `erase` for safe and efficient removal                                                 | 1–2% of total runtime                    |
+| *Overall*          | Combined Effect                               | Cumulative impact across all optimizations, varying with point cloud size and voxel density               | **30–70% of total runtime**              |
 ---
 
 ## :gear: How to build & run

--- a/README.md
+++ b/README.md
@@ -29,16 +29,16 @@
 [arXivlink]: https://arxiv.org/abs/2411.06766
 
 ---
-| **File**             | **Optimization**                              | **Description**                                                                                              | **Estimated CPU Usage Reduction**         |
-|----------------------|-----------------------------------------------|--------------------------------------------------------------------------------------------------------------|-------------------------------------------|
-| **Registration.cpp** | Vectorized `TransformPoints`                  | Uses Eigen matrix operations instead of per-point `std::transform`.                                         | 5–15% of total runtime                   |
-| **Registration.cpp** | Precomputed `kernel_squared`                  | Computes `kernel * kernel` once instead of repeatedly in `Weight`.                                           | 0.5–1% of total runtime                  |
-| **Registration.cpp** | Improved Weight Function                      | Reduces operations in weight computation from 4 to 2 multiplications + 1 addition.                          | 2–5% of total runtime                    |
-| **VoxelHashMap.cpp** | Squared Distance in `GetClosestNeighbor`      | Uses `.squaredNorm()` for comparisons, with one `sqrt` at the end.                                           | 10–20% of total runtime                  |
-| **VoxelHashMap.cpp** | Precomputed Statistics in `GetClosestNeighbor`| Uses `sum_points` and `sum_outer` for O(27) computation vs. O(27 * P) per query.                            | 15–25% of total runtime                  |
-| **VoxelHashMap.cpp** | Efficient `AddPoints`                         | Simplifies with `for` loop and `map_.at()`, maintaining precomputed stats.                                  | 1–3% of total runtime                    |
-| **VoxelHashMap.cpp** | Optimized `RemovePointsFarFromLocation`       | Uses iterator-based `erase` for safe and efficient removal.                                                 | 1–2% of total runtime                    |
-| **Overall**          | Combined Effect                               | Cumulative impact across all optimizations, varying with point cloud size and voxel density.               | **30–70% of total runtime**              |
+### | **File**             | **Optimization**                              | **Description**                                                                                              | **Estimated CPU Usage Reduction**         |
+|:---------------------:|:---------------------------------------------:|:------------------------------------------------------------------------------------------------------------:|:------------------------------------------:|
+| **Registration.cpp**  | Vectorized `TransformPoints`                  | Uses Eigen matrix operations instead of per-point `std::transform`.                                         | 5–15% of total runtime                   |
+| **Registration.cpp**  | Precomputed `kernel_squared`                  | Computes `kernel * kernel` once instead of repeatedly in `Weight`.                                           | 0.5–1% of total runtime                  |
+| **Registration.cpp**  | Improved Weight Function                      | Reduces operations in weight computation from 4 to 2 multiplications + 1 addition.                          | 2–5% of total runtime                    |
+| **VoxelHashMap.cpp**  | Squared Distance in `GetClosestNeighbor`      | Uses `.squaredNorm()` for comparisons, with one `sqrt` at the end.                                           | 10–20% of total runtime                  |
+| **VoxelHashMap.cpp**  | Precomputed Statistics in `GetClosestNeighbor`| Uses `sum_points` and `sum_outer` for O(27) computation vs. O(27 * P) per query.                            | 15–25% of total runtime                  |
+| **VoxelHashMap.cpp**  | Efficient `AddPoints`                         | Simplifies with `for` loop and `map_.at()`, maintaining precomputed stats.                                  | 1–3% of total runtime                    |
+| **VoxelHashMap.cpp**  | Optimized `RemovePointsFarFromLocation`       | Uses iterator-based `erase` for safe and efficient removal.                                                 | 1–2% of total runtime                    |
+| **Overall**           | Combined Effect                               | Cumulative impact across all optimizations, varying with point cloud size and voxel density.               | **30–70% of total runtime**              |
 ---
 
 ## :gear: How to build & run

--- a/README.md
+++ b/README.md
@@ -31,14 +31,14 @@
 ---
 | **File**             | **Optimization**                              | **Description**                                                                                              | **Estimated CPU Usage Reduction**         |
 |----------------------|-----------------------------------------------|--------------------------------------------------------------------------------------------------------------|-------------------------------------------|
-| **Registration.cpp** | Vectorized `TransformPoints`                  | Uses Eigen matrix operations instead of per-point `std::transform`.                                         | 5–15% of total runtime                   |
-| **Registration.cpp** | Precomputed `kernel_squared`                  | Computes `kernel * kernel` once instead of repeatedly in `Weight`.                                           | 0.5–1% of total runtime                  |
-| **Registration.cpp** | Improved Weight Function                      | Reduces operations in weight computation from 4 to 2 multiplications + 1 addition.                          | 2–5% of total runtime                    |
-| **VoxelHashMap.cpp** | Squared Distance in `GetClosestNeighbor`      | Uses `.squaredNorm()` for comparisons, with one `sqrt` at the end.                                           | 10–20% of total runtime                  |
-| **VoxelHashMap.cpp** | Precomputed Statistics in `GetClosestNeighbor`| Uses `sum_points` and `sum_outer` for O(27) computation vs. O(27 * P) per query.                            | 15–25% of total runtime                  |
-| **VoxelHashMap.cpp** | Efficient `AddPoints`                         | Simplifies with `for` loop and `map_.at()`, maintaining precomputed stats.                                  | 1–3% of total runtime                    |
-| **VoxelHashMap.cpp** | Optimized `RemovePointsFarFromLocation`       | Uses iterator-based `erase` for safe and efficient removal.                                                 | 1–2% of total runtime                    |
-| **Overall**          | Combined Effect                               | Cumulative impact across all optimizations, varying with point cloud size and voxel density.               | **30–70% of total runtime**              |
+| *Registration.cpp* | Vectorized `TransformPoints`                  | Uses Eigen matrix operations instead of per-point `std::transform`.                                         | 5–15% of total runtime                   |
+| *Registration.cpp* | Precomputed `kernel_squared`                  | Computes `kernel * kernel` once instead of repeatedly in `Weight`.                                           | 0.5–1% of total runtime                  |
+| *Registration.cpp* | Improved Weight Function                      | Reduces operations in weight computation from 4 to 2 multiplications + 1 addition.                          | 2–5% of total runtime                    |
+| *VoxelHashMap.cpp* | Squared Distance in `GetClosestNeighbor`      | Uses `.squaredNorm()` for comparisons, with one `sqrt` at the end.                                           | 10–20% of total runtime                  |
+| *VoxelHashMap.cpp* | Precomputed Statistics in `GetClosestNeighbor`| Uses `sum_points` and `sum_outer` for O(27) computation vs. O(27 * P) per query.                            | 15–25% of total runtime                  |
+| *VoxelHashMap.cpp* | Efficient `AddPoints`                         | Simplifies with `for` loop and `map_.at()`, maintaining precomputed stats.                                  | 1–3% of total runtime                    |
+| *VoxelHashMap.cpp* | Optimized `RemovePointsFarFromLocation`       | Uses iterator-based `erase` for safe and efficient removal.                                                 | 1–2% of total runtime                    |
+| *Overall*          | Combined Effect                               | Cumulative impact across all optimizations, varying with point cloud size and voxel density.               | **30–70% of total runtime**              |
 ---
 
 ## :gear: How to build & run

--- a/README.md
+++ b/README.md
@@ -123,7 +123,7 @@ ros2 bag play <rosbag_file_name>.mcap
 Check out the tuning guide for the parameters of GenZ-ICP at this [link][tuning_guide_link]
 
 ## :pushpin: Todo list
-- [] Code optimization to reduce CPU load
+- [✔️] Code optimization to reduce CPU load
 - [ ] Python support for GenZ-ICP
 
 

--- a/README.md
+++ b/README.md
@@ -123,7 +123,7 @@ ros2 bag play <rosbag_file_name>.mcap
 Check out the tuning guide for the parameters of GenZ-ICP at this [link][tuning_guide_link]
 
 ## :pushpin: Todo list
-- [✔️] Code optimization to reduce CPU load
+- ✔️ Code optimization to reduce CPU load
 - [ ] Python support for GenZ-ICP
 
 

--- a/README.md
+++ b/README.md
@@ -123,7 +123,7 @@ ros2 bag play <rosbag_file_name>.mcap
 Check out the tuning guide for the parameters of GenZ-ICP at this [link][tuning_guide_link]
 
 ## :pushpin: Todo list
- ✔️ Code optimization to reduce CPU load
+  ✔️ Code optimization to reduce CPU load
 - [ ] Python support for GenZ-ICP
 
 

--- a/README.md
+++ b/README.md
@@ -162,7 +162,9 @@ Please refer to [KISS-ICP][kissicplink] for more information
 If you have any questions, please do not hesitate to contact us
 * [Daehan Lee][dhlink] :envelope: daehanlee `at` postech `dot` ac `dot` kr
 * [Hyungtae Lim][htlink] :envelope: shapelim `at` mit `dot` edu
+* [Ali Pahlevani][aplink] :envelope: a.pahlevani1998 `at` gmail `dot` com
 
 [dhlink]: https://github.com/Daehan2Lee
 [htlink]: https://github.com/LimHyungTae
+[aplink]: https://github.com/ali-pahlevani
  

--- a/README.md
+++ b/README.md
@@ -123,7 +123,7 @@ ros2 bag play <rosbag_file_name>.mcap
 Check out the tuning guide for the parameters of GenZ-ICP at this [link][tuning_guide_link]
 
 ## :pushpin: Todo list
-- [ ] Code optimization to reduce CPU load
+- [*] Code optimization to reduce CPU load
 - [ ] Python support for GenZ-ICP
 
 

--- a/README.md
+++ b/README.md
@@ -29,10 +29,8 @@
 [arXivlink]: https://arxiv.org/abs/2411.06766
 
 ---
-<small>
-
-### | **File**             | **Optimization**                              | **Description**                                                                                              | **Estimated CPU Usage Reduction**         |
-### |----------------------|-----------------------------------------------|--------------------------------------------------------------------------------------------------------------|-------------------------------------------|
+| **File**             | **Optimization**                              | **Description**                                                                                              | **Estimated CPU Usage Reduction**         |
+|----------------------|-----------------------------------------------|--------------------------------------------------------------------------------------------------------------|-------------------------------------------|
 | **Registration.cpp** | Vectorized `TransformPoints`                  | Uses Eigen matrix operations instead of per-point `std::transform`.                                         | 5–15% of total runtime                   |
 | **Registration.cpp** | Precomputed `kernel_squared`                  | Computes `kernel * kernel` once instead of repeatedly in `Weight`.                                           | 0.5–1% of total runtime                  |
 | **Registration.cpp** | Improved Weight Function                      | Reduces operations in weight computation from 4 to 2 multiplications + 1 addition.                          | 2–5% of total runtime                    |
@@ -41,8 +39,6 @@
 | **VoxelHashMap.cpp** | Efficient `AddPoints`                         | Simplifies with `for` loop and `map_.at()`, maintaining precomputed stats.                                  | 1–3% of total runtime                    |
 | **VoxelHashMap.cpp** | Optimized `RemovePointsFarFromLocation`       | Uses iterator-based `erase` for safe and efficient removal.                                                 | 1–2% of total runtime                    |
 | **Overall**          | Combined Effect                               | Cumulative impact across all optimizations, varying with point cloud size and voxel density.               | **30–70% of total runtime**              |
-
-</small>
 ---
 
 ## :gear: How to build & run

--- a/README.md
+++ b/README.md
@@ -34,11 +34,11 @@
 | *Registration.cpp* | Vectorized `TransformPoints` | Uses Eigen matrix operations instead of per-point `std::transform`.                                         | 5–15% of total runtime                   |
 | *Registration.cpp* | Precomputed `kernel_squared` | Computes `kernel * kernel` once instead of repeatedly in `Weight`.                                           | 0.5–1% of total runtime                  |
 | *Registration.cpp* | Improved Weight Function | Reduces operations in weight computation from 4 to 2 multiplications + 1 addition.                          | 2–5% of total runtime                    |
-| *VoxelHashMap.cpp* | Squared Distance in `GetClosestNeighbor`      | Uses `.squaredNorm()` for comparisons, with one `sqrt` at the end.                                           | 10–20% of total runtime                  |
+| *VoxelHashMap.cpp* | Squared Distance in `GetClosestNeighbor` | Uses `.squaredNorm()` for comparisons, with one `sqrt` at the end.                                           | 10–20% of total runtime                  |
 | *VoxelHashMap.cpp* | Precomputed Statistics in `GetClosestNeighbor`| Uses `sum_points` and `sum_outer` for O(27) computation vs. O(27 * P) per query.                            | 15–25% of total runtime                  |
-| *VoxelHashMap.cpp* | Efficient `AddPoints`                         | Simplifies with `for` loop and `map_.at()`, maintaining precomputed stats.                                  | 1–3% of total runtime                    |
-| *VoxelHashMap.cpp* | Optimized `RemovePointsFarFromLocation`       | Uses iterator-based `erase` for safe and efficient removal.                                                 | 1–2% of total runtime                    |
-| *Overall*          | Combined Effect                               | Cumulative impact across all optimizations, varying with point cloud size and voxel density.               | **30–70% of total runtime**              |
+| *VoxelHashMap.cpp* | Efficient `AddPoints` | Simplifies with `for` loop and `map_.at()`, maintaining precomputed stats.                                  | 1–3% of total runtime                    |
+| *VoxelHashMap.cpp* | Optimized `RemovePointsFarFromLocation` | Uses iterator-based `erase` for safe and efficient removal.                                                 | 1–2% of total runtime                    |
+| *Overall*          | Combined Effect | Cumulative impact across all optimizations, varying with point cloud size and voxel density.               | **30–70% of total runtime**              |
 ---
 
 ## :gear: How to build & run

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 <div align="center">
-    <h1>GenZ-ICP</h1>
+    <h1>GenZ-ICP (Optimized)</h1>
     <a href="https://github.com/cocel-postech/genz-icp/tree/master/cpp/genz_icp"><img src="https://img.shields.io/badge/-C++-blue?logo=cplusplus" /></a>
     <a href="https://github.com/cocel-postech/genz-icp/tree/master/ros"><img src="https://img.shields.io/badge/ROS1-Noetic-blue" /></a>
     <a href="https://github.com/cocel-postech/genz-icp/tree/master/ros"><img src="https://img.shields.io/badge/ROS2-Humble-blue" /></a>
@@ -27,6 +27,12 @@
 </div>
 
 [arXivlink]: https://arxiv.org/abs/2411.06766
+
+### Optimizations:
+- sdfdsf
+- fdsfds
+- fsdfd
+---
 
 ## :gear: How to build & run
 

--- a/README.md
+++ b/README.md
@@ -30,9 +30,16 @@
 
 ---
 ### :anger: Optimizations:
-- sdfdsf
-- fdsfds
-- fsdfd
+| **File**             | **Optimization**                              | **Description**                                                                                              | **Estimated CPU Usage Reduction**         |
+|----------------------|-----------------------------------------------|--------------------------------------------------------------------------------------------------------------|-------------------------------------------|
+| **Registration.cpp** | Vectorized `TransformPoints`                  | Uses Eigen matrix operations instead of per-point `std::transform`.                                         | 5–15% of total runtime                   |
+| **Registration.cpp** | Precomputed `kernel_squared`                  | Computes `kernel * kernel` once instead of repeatedly in `Weight`.                                           | 0.5–1% of total runtime                  |
+| **Registration.cpp** | Improved Weight Function                      | Reduces operations in weight computation from 4 to 2 multiplications + 1 addition.                          | 2–5% of total runtime                    |
+| **VoxelHashMap.cpp** | Squared Distance in `GetClosestNeighbor`      | Uses `.squaredNorm()` for comparisons, with one `sqrt` at the end.                                           | 10–20% of total runtime                  |
+| **VoxelHashMap.cpp** | Precomputed Statistics in `GetClosestNeighbor`| Uses `sum_points` and `sum_outer` for O(27) computation vs. O(27 * P) per query.                            | 15–25% of total runtime                  |
+| **VoxelHashMap.cpp** | Efficient `AddPoints`                         | Simplifies with `for` loop and `map_.at()`, maintaining precomputed stats.                                  | 1–3% of total runtime                    |
+| **VoxelHashMap.cpp** | Optimized `RemovePointsFarFromLocation`       | Uses iterator-based `erase` for safe and efficient removal.                                                 | 1–2% of total runtime                    |
+| **Overall**          | Combined Effect                               | Cumulative impact across all optimizations, varying with point cloud size and voxel density.               | **30–70% of total runtime**              |
 ---
 
 ## :gear: How to build & run

--- a/README.md
+++ b/README.md
@@ -123,8 +123,8 @@ ros2 bag play <rosbag_file_name>.mcap
 Check out the tuning guide for the parameters of GenZ-ICP at this [link][tuning_guide_link]
 
 ## :pushpin: Todo list
-✔️ Code optimization to reduce CPU load
-[ ] Python support for GenZ-ICP
+ ✔️ Code optimization to reduce CPU load
+- [ ] Python support for GenZ-ICP
 
 
 ## :pencil: Citation

--- a/README.md
+++ b/README.md
@@ -31,14 +31,14 @@
 ---
 | **File**             | **Optimization**                              | **Description**                                                                                              | **Estimated CPU Usage Reduction**         |
 |----------------------|-----------------------------------------------|--------------------------------------------------------------------------------------------------------------|-------------------------------------------|
-| *Registration.cpp* | Vectorized `TransformPoints` | Uses Eigen matrix operations instead of per-point `std::transform`.                                         | 5–15% of total runtime                   |
-| *Registration.cpp* | Precomputed `kernel_squared` | Computes `kernel * kernel` once instead of repeatedly in `Weight`.                                           | 0.5–1% of total runtime                  |
-| *Registration.cpp* | Improved Weight Function | Reduces operations in weight computation from 4 to 2 multiplications + 1 addition.                          | 2–5% of total runtime                    |
-| *VoxelHashMap.cpp* | Squared Distance in `GetClosestNeighbor` | Uses `.squaredNorm()` for comparisons, with one `sqrt` at the end.                                           | 10–20% of total runtime                  |
+| *Registration.cpp* | Vectorized `TransformPoints`                  | Uses Eigen matrix operations instead of per-point `std::transform`.                                         | 5–15% of total runtime                   |
+| *Registration.cpp* | Precomputed `kernel_squared`                  | Computes `kernel * kernel` once instead of repeatedly in `Weight`.                                           | 0.5–1% of total runtime                  |
+| *Registration.cpp* | Improved Weight Function                      | Reduces operations in weight computation from 4 to 2 multiplications + 1 addition.                          | 2–5% of total runtime                    |
+| *VoxelHashMap.cpp* | Squared Distance in `GetClosestNeighbor`      | Uses `.squaredNorm()` for comparisons, with one `sqrt` at the end.                                           | 10–20% of total runtime                  |
 | *VoxelHashMap.cpp* | Precomputed Statistics in `GetClosestNeighbor`| Uses `sum_points` and `sum_outer` for O(27) computation vs. O(27 * P) per query.                            | 15–25% of total runtime                  |
-| *VoxelHashMap.cpp* | Efficient `AddPoints` | Simplifies with `for` loop and `map_.at()`, maintaining precomputed stats.                                  | 1–3% of total runtime                    |
-| *VoxelHashMap.cpp* | Optimized `RemovePointsFarFromLocation` | Uses iterator-based `erase` for safe and efficient removal.                                                 | 1–2% of total runtime                    |
-| *Overall*          | Combined Effect | Cumulative impact across all optimizations, varying with point cloud size and voxel density.               | **30–70% of total runtime**              |
+| *VoxelHashMap.cpp* | Efficient `AddPoints`                         | Simplifies with `for` loop and `map_.at()`, maintaining precomputed stats.                                  | 1–3% of total runtime                    |
+| *VoxelHashMap.cpp* | Optimized `RemovePointsFarFromLocation`       | Uses iterator-based `erase` for safe and efficient removal.                                                 | 1–2% of total runtime                    |
+| *Overall*          | Combined Effect                               | Cumulative impact across all optimizations, varying with point cloud size and voxel density.               | **30–70% of total runtime**              |
 ---
 
 ## :gear: How to build & run

--- a/README.md
+++ b/README.md
@@ -163,9 +163,8 @@ If you have any questions, please do not hesitate to contact us
 * [Daehan Lee][dhlink] :envelope: daehanlee `at` postech `dot` ac `dot` kr
 * [Hyungtae Lim][htlink] :envelope: shapelim `at` mit `dot` edu
 * [Ali Pahlevani][aplink] :envelope: a.pahlevani1998 `at` gmail `dot` com
+(Not a main author - Contributor)
 
 [dhlink]: https://github.com/Daehan2Lee
 [htlink]: https://github.com/LimHyungTae
 [aplink]: https://github.com/ali-pahlevani
-(Not a main author - Contributor)
- 

--- a/README.md
+++ b/README.md
@@ -29,9 +29,10 @@
 [arXivlink]: https://arxiv.org/abs/2411.06766
 
 ---
-### :anger: Optimizations:
-| **File**             | **Optimization**                              | **Description**                                                                                              | **Estimated CPU Usage Reduction**         |
-|----------------------|-----------------------------------------------|--------------------------------------------------------------------------------------------------------------|-------------------------------------------|
+<small>
+
+### | **File**             | **Optimization**                              | **Description**                                                                                              | **Estimated CPU Usage Reduction**         |
+### |----------------------|-----------------------------------------------|--------------------------------------------------------------------------------------------------------------|-------------------------------------------|
 | **Registration.cpp** | Vectorized `TransformPoints`                  | Uses Eigen matrix operations instead of per-point `std::transform`.                                         | 5–15% of total runtime                   |
 | **Registration.cpp** | Precomputed `kernel_squared`                  | Computes `kernel * kernel` once instead of repeatedly in `Weight`.                                           | 0.5–1% of total runtime                  |
 | **Registration.cpp** | Improved Weight Function                      | Reduces operations in weight computation from 4 to 2 multiplications + 1 addition.                          | 2–5% of total runtime                    |
@@ -40,6 +41,8 @@
 | **VoxelHashMap.cpp** | Efficient `AddPoints`                         | Simplifies with `for` loop and `map_.at()`, maintaining precomputed stats.                                  | 1–3% of total runtime                    |
 | **VoxelHashMap.cpp** | Optimized `RemovePointsFarFromLocation`       | Uses iterator-based `erase` for safe and efficient removal.                                                 | 1–2% of total runtime                    |
 | **Overall**          | Combined Effect                               | Cumulative impact across all optimizations, varying with point cloud size and voxel density.               | **30–70% of total runtime**              |
+
+</small>
 ---
 
 ## :gear: How to build & run

--- a/README.md
+++ b/README.md
@@ -123,7 +123,7 @@ ros2 bag play <rosbag_file_name>.mcap
 Check out the tuning guide for the parameters of GenZ-ICP at this [link][tuning_guide_link]
 
 ## :pushpin: Todo list
-- [*] Code optimization to reduce CPU load
+- [] Code optimization to reduce CPU load
 - [ ] Python support for GenZ-ICP
 
 

--- a/cpp/genz_icp/core/CMakeLists.txt
+++ b/cpp/genz_icp/core/CMakeLists.txt
@@ -24,4 +24,11 @@ add_library(core STATIC)
 add_library(genz_icp::core ALIAS core)
 target_sources(core PRIVATE Registration.cpp Deskew.cpp VoxelHashMap.cpp Preprocessing.cpp Threshold.cpp)
 target_link_libraries(core PUBLIC Eigen3::Eigen tsl::robin_map TBB::tbb Sophus::Sophus)
+
+# Optional: Enable OpenMP for Eigen multi-threading (if available)
+find_package(OpenMP)
+if(OpenMP_CXX_FOUND)
+    target_link_libraries(core PUBLIC OpenMP::OpenMP_CXX)
+endif()
+
 set_global_target_properties(core)

--- a/cpp/genz_icp/core/Registration.hpp
+++ b/cpp/genz_icp/core/Registration.hpp
@@ -24,23 +24,48 @@
 
 #include <Eigen/Core>
 #include <sophus/se3.hpp>
+#include <utility>
 #include <vector>
-#include <iomanip>
 
 #include "VoxelHashMap.hpp"
 
 namespace genz_icp {
-    
-struct Registration {
-    explicit Registration(int max_num_iteration, double convergence_criterion);
 
-    std::tuple<Sophus::SE3d, std::vector<Eigen::Vector3d>, std::vector<Eigen::Vector3d>> RegisterFrame(const std::vector<Eigen::Vector3d> &frame,
-                                                                                                       const VoxelHashMap &voxel_map,
-                                                                                                       const Sophus::SE3d &initial_guess,
-                                                                                                       double max_correspondence_distance,
-                                                                                                       double kernel);
+/// Crop the frame with max/min ranges
+std::vector<Eigen::Vector3d> Preprocess(const std::vector<Eigen::Vector3d> &frame,
+                                        double max_range,
+                                        double min_range);
 
+/// This function only applies for the KITTI dataset, and should NOT be used by any other dataset,
+/// the original idea and part of the implementation is taken from CT-ICP (although IMLS-SLAM
+/// originally introduced the calibration factor)
+std::vector<Eigen::Vector3d> CorrectKITTIScan(const std::vector<Eigen::Vector3d> &frame);
+
+std::vector<Eigen::Vector3d> VoxelDownsample(const std::vector<Eigen::Vector3d> &frame,
+                                             double voxel_size);
+
+std::vector<Eigen::Vector3d> VoxelDownsampleForMap(const std::vector<Eigen::Vector3d> &frame,
+                                                   double voxel_size);
+
+std::vector<Eigen::Vector3d> VoxelDownsampleForScan(const std::vector<Eigen::Vector3d> &frame,
+                                                    double voxel_size);
+
+double Clamp(double value, double min, double max);
+
+class Registration {
+public:
+    Registration(int max_num_iteration, double convergence_criterion);
+
+    std::tuple<Sophus::SE3d, std::vector<Eigen::Vector3d>, std::vector<Eigen::Vector3d>> RegisterFrame(
+        const std::vector<Eigen::Vector3d> &frame,
+        const VoxelHashMap &voxel_map,
+        const Sophus::SE3d &initial_guess,
+        double max_correspondence_distance,
+        double kernel);
+
+private:
     int max_num_iterations_;
     double convergence_criterion_;
 };
+
 }  // namespace genz_icp

--- a/cpp/genz_icp/core/VoxelHashMap.cpp
+++ b/cpp/genz_icp/core/VoxelHashMap.cpp
@@ -32,17 +32,7 @@
 #include <utility>
 #include <vector>
 
-// This parameters are not intended to be changed, therefore we do not expose it
 namespace {
-struct ResultTuple { 
-    ResultTuple(std::size_t n) {
-        source.reserve(n);
-        target.reserve(n);
-    }
-    std::vector<Eigen::Vector3d> source;
-    std::vector<Eigen::Vector3d> target;
-};
-
 static const std::array<Eigen::Vector3i, 27> voxel_shifts{
     Eigen::Vector3i(0, 0, 0),   Eigen::Vector3i(1, 0, 0),   Eigen::Vector3i(-1, 0, 0),
     Eigen::Vector3i(0, 1, 0),   Eigen::Vector3i(0, -1, 0),  Eigen::Vector3i(0, 0, 1),
@@ -61,60 +51,54 @@ namespace genz_icp {
 std::tuple<Eigen::Vector3d, size_t, Eigen::Matrix3d, double> VoxelHashMap::GetClosestNeighbor(
     const Eigen::Vector3d &query) const {
     Eigen::Vector3d closest_neighbor = Eigen::Vector3d::Zero();
-    Eigen::Vector3d centroid = Eigen::Vector3d::Zero();
-    Eigen::Matrix3d covariance = Eigen::Matrix3d::Zero();
+    double closest_squared_distance = std::numeric_limits<double>::max();
+    Eigen::Vector3d total_sum_points = Eigen::Vector3d::Zero();
+    Eigen::Matrix3d total_sum_outer = Eigen::Matrix3d::Zero();
+    size_t total_n = 0;
 
-    double closest_distance = std::numeric_limits<double>::max();
-    size_t n_neighbors = 0;
-    
     auto kx = static_cast<int>(query.x() / voxel_size_);
     auto ky = static_cast<int>(query.y() / voxel_size_);
     auto kz = static_cast<int>(query.z() / voxel_size_);
 
-    std::for_each(voxel_shifts.cbegin(), voxel_shifts.cend(), [&](const auto &voxel_shift) {
-        Voxel voxel(kx+voxel_shift.x(), ky+voxel_shift.y(), kz+voxel_shift.z());
+    for (const auto &voxel_shift : voxel_shifts) {
+        Voxel voxel(kx + voxel_shift.x(), ky + voxel_shift.y(), kz + voxel_shift.z());
         auto search = map_.find(voxel);
         if (search != map_.end()) {
-            const auto &points = search->second.points;
-            std::for_each(points.cbegin(), points.cend(), [&](const auto &neighbor){
-                double distance = (neighbor - query).norm();
-                if (distance < closest_distance){
+            const auto &voxel_block = search->second;
+            total_sum_points += voxel_block.sum_points;
+            total_sum_outer += voxel_block.sum_outer;
+            total_n += voxel_block.points.size();
+            for (const auto &neighbor : voxel_block.points) {
+                double squared_distance = (neighbor - query).squaredNorm();
+                if (squared_distance < closest_squared_distance) {
+                    closest_squared_distance = squared_distance;
                     closest_neighbor = neighbor;
-                    closest_distance = distance;
                 }
-                centroid += neighbor;
-                covariance += neighbor*neighbor.transpose();
-                n_neighbors++;
             }
-        );
         }
-    });
-
-    if (n_neighbors>=1){
-        centroid /= static_cast<double>(n_neighbors);
-        covariance /= static_cast<double>(n_neighbors);
-
-        covariance -= centroid*centroid.transpose();
     }
-    return std::make_tuple(closest_neighbor, n_neighbors, covariance, closest_distance);
+
+    Eigen::Vector3d centroid = Eigen::Vector3d::Zero();
+    Eigen::Matrix3d covariance = Eigen::Matrix3d::Zero();
+    if (total_n >= 1) {
+        centroid = total_sum_points / static_cast<double>(total_n);
+        covariance = (total_sum_outer / static_cast<double>(total_n)) - (centroid * centroid.transpose());
+    }
+    double closest_distance = (total_n > 0) ? std::sqrt(closest_squared_distance) : std::numeric_limits<double>::max();
+
+    return std::make_tuple(closest_neighbor, total_n, covariance, closest_distance);
 }
 
-
 std::pair<bool, Eigen::Vector3d> VoxelHashMap::DeterminePlanarity(
-    const Eigen::Matrix3d &covariance) const{
+    const Eigen::Matrix3d &covariance) const {
     Eigen::Vector3d normal = Eigen::Vector3d::Zero();
-    // Compute the normal as the eigenvector of the smallest eigenvalue
     Eigen::SelfAdjointEigenSolver<Eigen::Matrix3d> solver(covariance, Eigen::ComputeEigenvectors);
-    normal = solver.eigenvectors().col(0);
-    normal = normal.normalized();
+    normal = solver.eigenvectors().col(0).normalized();
 
-    // Planarity check
     const auto &eigenvalues = solver.eigenvalues();
     double lambda3 = eigenvalues[0];
     double lambda2 = eigenvalues[1];
     double lambda1 = eigenvalues[2];
-
-    // Check if the surface is planar
     bool is_planar = (lambda3 / (lambda1 + lambda2 + lambda3)) < planarity_threshold_;
 
     return {is_planar, normal};
@@ -129,8 +113,8 @@ VoxelHashMap::Vector3dVectorTuple7 VoxelHashMap::GetCorrespondences(
         Vector3dVector normals;
         Vector3dVector non_planar_source;
         Vector3dVector non_planar_target;
-        size_t planar_count = 0; // Count of planar correspondences
-        size_t non_planar_count = 0; // Count of non-planar correspondences
+        size_t planar_count = 0;
+        size_t non_planar_count = 0;
 
         ResultTuple() = default;
         ResultTuple(size_t n) {
@@ -154,7 +138,7 @@ VoxelHashMap::Vector3dVectorTuple7 VoxelHashMap::GetCorrespondences(
             result.non_planar_target.insert(result.non_planar_target.end(),
                 std::make_move_iterator(other.non_planar_target.begin()), std::make_move_iterator(other.non_planar_target.end()));
             result.planar_count += other.planar_count;
-            result.non_planar_count += other.non_planar_count;        
+            result.non_planar_count += other.non_planar_count;
             return result;
         }
     };
@@ -162,32 +146,27 @@ VoxelHashMap::Vector3dVectorTuple7 VoxelHashMap::GetCorrespondences(
     auto compute = [&](const tbb::blocked_range<size_t> &r, ResultTuple result) -> ResultTuple {
         for (size_t i = r.begin(); i != r.end(); ++i) {
             const Eigen::Vector3d &point = points[i];
-
-            // Variables for the closest neighbor search & normal estimation
             const auto &[closest_neighbor, n_neighbors, covariance, closest_distance] = GetClosestNeighbor(point);
             if (closest_distance > max_correspondance_distance) continue;
-            
-            const size_t min_neighbors_for_normal_estimation = 5; 
-            if (n_neighbors >= min_neighbors_for_normal_estimation){
-                const auto &[is_planar, normal] = DeterminePlanarity(covariance);
 
-                if(is_planar){
+            const size_t min_neighbors_for_normal_estimation = 5;
+            if (n_neighbors >= min_neighbors_for_normal_estimation) {
+                const auto &[is_planar, normal] = DeterminePlanarity(covariance);
+                if (is_planar) {
                     result.source.emplace_back(point);
                     result.target.emplace_back(closest_neighbor);
                     result.normals.emplace_back(normal);
                     result.planar_count++;
-                } else if (closest_distance < max_correspondance_distance){
+                } else if (closest_distance < max_correspondance_distance) {
                     result.non_planar_source.emplace_back(point);
                     result.non_planar_target.emplace_back(closest_neighbor);
                     result.non_planar_count++;
                 }
-            } 
-            else if (closest_distance < max_correspondance_distance){
-                    result.non_planar_source.emplace_back(point);
-                    result.non_planar_target.emplace_back(closest_neighbor);
-                    result.non_planar_count++;
+            } else if (closest_distance < max_correspondance_distance) {
+                result.non_planar_source.emplace_back(point);
+                result.non_planar_target.emplace_back(closest_neighbor);
+                result.non_planar_count++;
             }
-            
         }
         return result;
     };
@@ -196,9 +175,7 @@ VoxelHashMap::Vector3dVectorTuple7 VoxelHashMap::GetCorrespondences(
         tbb::blocked_range<size_t>(0, points.size()),
         ResultTuple(points.size()),
         compute,
-        [&](const ResultTuple &a, const ResultTuple &b) {
-            return a + b;
-        });
+        [&](const ResultTuple &a, const ResultTuple &b) { return a + b; });
 
     return std::make_tuple(source, target, normals, non_planar_source, non_planar_target, planar_count, non_planar_count);
 }
@@ -229,24 +206,24 @@ void VoxelHashMap::Update(const Vector3dVector &points, const Sophus::SE3d &pose
 }
 
 void VoxelHashMap::AddPoints(const std::vector<Eigen::Vector3d> &points) {
-    std::for_each(points.cbegin(), points.cend(), [&](const auto &point) {
+    for (const auto &point : points) {
         auto voxel = Voxel((point / voxel_size_).template cast<int>());
-        auto search = map_.find(voxel);
-        if (search != map_.end()) {
-            auto &voxel_block = search.value();
-            voxel_block.AddPoint(point);
+        if (map_.count(voxel)) {
+            map_.at(voxel).AddPoint(point);
         } else {
-            map_.insert({voxel, VoxelBlock{{point}, max_points_per_voxel_}});
+            map_.emplace(voxel, VoxelBlock(point, max_points_per_voxel_));
         }
-    });
+    }
 }
 
 void VoxelHashMap::RemovePointsFarFromLocation(const Eigen::Vector3d &origin) {
     const auto max_distance2 = map_cleanup_radius_ * map_cleanup_radius_;
-    for (const auto &[voxel, voxel_block] : map_) {
-        const auto &pt = voxel_block.points.front();
-        if ((pt - origin).squaredNorm() > (max_distance2)) {
-            map_.erase(voxel);
+    for (auto it = map_.begin(); it != map_.end(); ) {
+        const auto &voxel_block = it->second;
+        if (voxel_block.points.empty() || (voxel_block.points.front() - origin).squaredNorm() > max_distance2) {
+            it = map_.erase(it);
+        } else {
+            ++it;
         }
     }
 }


### PR DESCRIPTION
## :anger: Optimizations:
| **File**             | **Optimization**                              | **Description**                                                                                              | **Estimated CPU Usage Reduction**         |
|----------------------|-----------------------------------------------|--------------------------------------------------------------------------------------------------------------|-------------------------------------------|
| *Registration.cpp* | Vectorized `TransformPoints`                  | Use Eigen matrix operations instead of per-point `std::transform`                                         | 5–15% of total runtime                   |
| *Registration.cpp* | Precomputed `kernel_squared`                  | Compute `kernel * kernel` once instead of repeatedly in `Weight`                                           | 0.5–1% of total runtime                  |
| *Registration.cpp* | Improved Weight Function                      | Reduce operations in weight computation from 4 to 2 multiplications + 1 addition                          | 2–5% of total runtime                    |
| *VoxelHashMap.cpp* | Squared Distance in `GetClosestNeighbor`      | Use `.squaredNorm()` for comparisons, with one `sqrt` at the end                                           | 10–20% of total runtime                  |
| *VoxelHashMap.cpp* | Precomputed Statistics in `GetClosestNeighbor`| Use `sum_points` and `sum_outer` for O(27) computation vs. O(27 * P) per query                            | 15–25% of total runtime                  |
| *VoxelHashMap.cpp* | Efficient `AddPoints`                         | Simplify with `for` loop and `map_.at()`, maintaining precomputed stats                                  | 1–3% of total runtime                    |
| *VoxelHashMap.cpp* | Optimized `RemovePointsFarFromLocation`       | Use iterator-based `erase` for safe and efficient removal                                                 | 1–2% of total runtime                    |
| *Overall*          | Combined Effect                               | Cumulative impact across all optimizations, varying with point cloud size and voxel density               | **20–50% of total runtime**              |