### PR TITLE
Preallocate memory for voxel point buffers to improve efficiency

### DIFF
--- a/cpp/genz_icp/core/VoxelHashMap.cpp
+++ b/cpp/genz_icp/core/VoxelHashMap.cpp
@@ -245,10 +245,11 @@ void VoxelHashMap::AddPoints(const std::vector<Eigen::Vector3d> &points) {
 
 void VoxelHashMap::RemovePointsFarFromLocation(const Eigen::Vector3d &origin) {
     const auto max_distance2 = map_cleanup_radius_ * map_cleanup_radius_;
-    for (const auto &[voxel, voxel_block] : map_) {
-        const auto &pt = voxel_block.points.front();
-        if ((pt - origin).squaredNorm() > (max_distance2)) {
-            map_.erase(voxel);
+    for (auto it = map_.begin(); it != map_.end();) {
+        if ((it->second.points.front() - origin).squaredNorm() > (max_distance2)) {
+            it = map_.erase(it);
+        } else {
+            ++it;
         }
     }
 }

--- a/cpp/genz_icp/core/VoxelHashMap.cpp
+++ b/cpp/genz_icp/core/VoxelHashMap.cpp
@@ -238,7 +238,7 @@ void VoxelHashMap::AddPoints(const std::vector<Eigen::Vector3d> &points) {
             auto &voxel_block = search.value();
             voxel_block.AddPoint(point);
         } else {
-            map_.insert({voxel, VoxelBlock{{point}, max_points_per_voxel_}});
+            map_.insert({voxel, VoxelBlock(point, max_points_per_voxel_)});
         }
     });
 }

--- a/cpp/genz_icp/core/VoxelHashMap.hpp
+++ b/cpp/genz_icp/core/VoxelHashMap.hpp
@@ -42,9 +42,9 @@ struct VoxelHashMap {
         // buffer of points with a max limit of n_points
         std::vector<Eigen::Vector3d> points;
         int num_points_;
-        VoxelBlock(const Eigen::Vector3d &pt, int max_points) : points(), num_points_(max_points) {
+        VoxelBlock(const Eigen::Vector3d &point, int max_points) : points(), num_points_(max_points) {
             points.reserve(static_cast<size_t>(num_points_));
-            points.emplace_back(pt);
+            points.emplace_back(point);
         }
         inline void AddPoint(const Eigen::Vector3d &point) {
             if (points.size() < static_cast<size_t>(num_points_)) points.emplace_back(point);

--- a/cpp/genz_icp/core/VoxelHashMap.hpp
+++ b/cpp/genz_icp/core/VoxelHashMap.hpp
@@ -42,8 +42,12 @@ struct VoxelHashMap {
         // buffer of points with a max limit of n_points
         std::vector<Eigen::Vector3d> points;
         int num_points_;
+        VoxelBlock(const Eigen::Vector3d &pt, int max_points) : points(), num_points_(max_points) {
+            points.reserve(static_cast<size_t>(num_points_));
+            points.emplace_back(pt);
+        }
         inline void AddPoint(const Eigen::Vector3d &point) {
-            if (points.size() < static_cast<size_t>(num_points_)) points.push_back(point);
+            if (points.size() < static_cast<size_t>(num_points_)) points.emplace_back(point);
         }
     };
     struct VoxelHash {


### PR DESCRIPTION
Each `VoxelBlock` now pre-reserves memory for point storage based on `max_points_per_voxel_` to reduce dynamic allocations.