### PR TITLE
Apply type-safe config overrides in ROS2

### DIFF
--- a/ros/ros2/OdometryServer.cpp
+++ b/ros/ros2/OdometryServer.cpp
@@ -93,14 +93,8 @@ OdometryServer::OdometryServer(const rclcpp::NodeOptions &options)
             if (value.IsScalar()) {
                 // Get the declared type of the parameter
                 rcl_interfaces::msg::ParameterDescriptor descriptor;
-                try {
-                    descriptor = this->describe_parameter(name);
-                } catch (const rclcpp::exceptions::ParameterNotDeclaredException &e) {
-                    // If the parameter wasn't declared, warn and skip
-                    RCLCPP_WARN(this->get_logger(), "Parameter '%s' not declared. Skipping it.", name.c_str());
-                    continue;
-                }
-    
+                descriptor = this->describe_parameter(name);
+
                 using ParamType = rcl_interfaces::msg::ParameterType;
                 switch (descriptor.type) {
                     case ParamType::PARAMETER_DOUBLE:


### PR DESCRIPTION
### Problem

In the current implementation, parameters loaded from a YAML config are parsed in a fixed order (in ROS2):

- **int → double → bool → string**

This leads to a following issue:

- **Silent override failures**: e.g. a `double` parameter like `map_cleanup_radius` given as `300` (an integer) is parsed as `int`, rejected by ROS 2, and it's default `100.0` is silently used.

### Change

Lookup each parameter’s declared type and parse accordingly:

- `double`: accept integer or floating‑point scalars (integers are cast to `double`).

- `integer`, `bool`, `string`: only accept matching YAML scalar types; on mismatch log an ERROR and throw a `ParameterTypeException` to fail fast.
