### PR TITLE
fix: rename ROS 2 component library to avoid libodometry_component.so collision with KISS-ICP

### DIFF
--- a/ros/CMakeLists.txt
+++ b/ros/CMakeLists.txt
@@ -80,12 +80,12 @@ elseif("$ENV{ROS_VERSION}" STREQUAL "2")
   find_package(yaml-cpp REQUIRED)
 
   # ROS 2 node
-  add_library(odometry_component SHARED ros2/OdometryServer.cpp)
-  target_compile_features(odometry_component PUBLIC cxx_std_20)
-  target_include_directories(odometry_component PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/include)
-  target_link_libraries(odometry_component genz_icp::pipeline yaml-cpp)
+  add_library(genz_icp_odometry_component SHARED ros2/OdometryServer.cpp)
+  target_compile_features(genz_icp_odometry_component PUBLIC cxx_std_20)
+  target_include_directories(genz_icp_odometry_component PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/include)
+  target_link_libraries(genz_icp_odometry_component genz_icp::pipeline yaml-cpp)
   ament_target_dependencies(
-    odometry_component
+    genz_icp_odometry_component
     rcutils
     rclcpp
     rclcpp_components
@@ -96,9 +96,9 @@ elseif("$ENV{ROS_VERSION}" STREQUAL "2")
     tf2_ros
     ament_index_cpp)
 
-  rclcpp_components_register_node(odometry_component PLUGIN "genz_icp_ros::OdometryServer" EXECUTABLE odometry_node)
+  rclcpp_components_register_node(genz_icp_odometry_component PLUGIN "genz_icp_ros::OdometryServer" EXECUTABLE odometry_node)
 
-  install(TARGETS odometry_component LIBRARY DESTINATION lib RUNTIME DESTINATION lib/${PROJECT_NAME})
+  install(TARGETS genz_icp_odometry_component LIBRARY DESTINATION lib RUNTIME DESTINATION lib/${PROJECT_NAME})
   install(DIRECTORY launch rviz config DESTINATION share/${PROJECT_NAME}/)
 
   ament_package()


### PR DESCRIPTION
## Summary
Renames the ROS 2 shared library target in `ros/CMakeLists.txt` from `odometry_component` to `genz_icp_odometry_component`, so the produced artifact becomes `libgenz_icp_odometry_component.so` instead of `libodometry_component.so`. This stops the standalone `odometry_node` executable from silently loading KISS-ICP's identically named library when both packages are sourced in the same workspace.

## Why this matters
As diagnosed in #37, the stock `odometry_node` executable starts but never instantiates `genz_icp_ros::OdometryServer`: no init log, no `/genz/odometry` topics, the executor spins an empty node. The root cause is a filename collision: the GenZ-ICP component library and KISS-ICP both produce `libodometry_component.so`, so the component-node executable's library lookup resolves the wrong `.so` and the registered node factory is never found. Giving the target a package-unique name removes the collision. This also resolves the identical "node never enters constructor" symptom reported in #23.

`EXECUTABLE odometry_node` and the plugin class string `genz_icp_ros::OdometryServer` are left unchanged, so the documented launch command and `odometry.launch.py` (which references `executable="odometry_node"`) keep working with no launch-file edits. Only the ROS 2 branch is touched; the ROS 1 `odometry_node` executable target is unrelated and untouched.

## Testing
No build run here (no ROS 2 / colcon toolchain in this environment). The change is a self-contained CMake target rename, verified to be internally consistent: all seven references to the old target name within the ROS 2 branch are updated (`add_library`, `target_compile_features`, `target_include_directories`, `target_link_libraries`, `ament_target_dependencies`, `rclcpp_components_register_node`, `install(TARGETS ...)`), and no other references to the old name remain anywhere in the repo.

Fixes #37
